### PR TITLE
Add possibility to add pullsecret to helm chart

### DIFF
--- a/charts/service-broker-proxy-k8s/Chart.yaml
+++ b/charts/service-broker-proxy-k8s/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "master"
 description: A Helm chart for Service Broker Proxy for Kubernetes
 name: service-broker-proxy-k8s
-version: 0.3.0
+version: 0.4.0

--- a/charts/service-broker-proxy-k8s/README.md
+++ b/charts/service-broker-proxy-k8s/README.md
@@ -21,7 +21,8 @@ helm install charts/service-broker-proxy-k8s --name service-broker-proxy --names
 
 **Note:** Make sure you substitute &lt;SM_URL&gt; with the Service Manager url, &lt;USER&gt; and &lt;PASSWORD&gt; with the credentials for the Service Manager. The credentials can be obtained when registering the cluster in Service Manager.
 
-To use your own images you can set `image.repository`, `image.tag` and `image.pullPolicy` to the helm install command.
+To use your own images you can set `image.repository`, `image.tag` and `image.pullPolicy` to the helm install command. In case your image is pulled from a private repository, you can use
+`image.pullsecret` to name a secret containing the credentials.
 ## Configuration
 
 The following table lists the configurable parameters of the service broker proxy for K8S chart and their default values.
@@ -30,6 +31,7 @@ Parameter | Description | Default
 --------- | ----------- | -------
 `image.repository`| image repository |`quay.io/service-manager/sb-proxy-k8s`
 `image.tag`| tag of image  |`master`
+`image.pullsecret` | name of the secret containing pull secrets |
 `config.sm.url` | service manager url | `http://service-manager.local.pcfdev.io`
 `sm.user` | username | `admin`
 `sm.password` | password | `admin`

--- a/charts/service-broker-proxy-k8s/templates/deployment.yaml
+++ b/charts/service-broker-proxy-k8s/templates/deployment.yaml
@@ -28,6 +28,10 @@ spec:
           configMap:
             name: {{ template "service-broker-proxy.fullname" . }}-config
       serviceAccountName: {{ template "service-broker-proxy.fullname" . }}
+      {{- if .Values.image.pullsecret }}
+      imagePullSecrets:
+      - name: {{.Values.image.pullsecret}}
+      {{- end }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/service-broker-proxy-k8s/values.yaml
+++ b/charts/service-broker-proxy-k8s/values.yaml
@@ -8,6 +8,7 @@ image:
   repository: quay.io/service-manager/sb-proxy-k8s
   tag: master
   pullPolicy: Always
+  pullsecret:
 
 service:
   type: ClusterIP


### PR DESCRIPTION
In order to use an image from a private repo, the deployment needs the name of the secret containing the pull credentials. This is optional and not needed for public repos.