### PR TITLE
Downgrade to Go 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.12.x
+  - 1.11.x
 
 # set tag for helm chart
 env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # docker container. The alpine build image has to match
 # the alpine image in the referencing runtime container.
 #########################################################
-FROM golang:1.12.13-alpine3.10 AS builder
+FROM golang:1.11.13-alpine3.10 AS builder
 
 # We need so that dep can fetch it's dependencies
 # RUN apk --no-cache add git


### PR DESCRIPTION
# Downgrade to Go 1.11

Motivation: https://github.com/golang/go/issues/35373