### PR TITLE
Add .pipeline to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ kubeconfig*
 
 # vendor
 /vendor
+
+# Pipeline specific
+.pipeline/


### PR DESCRIPTION
## Motivation

The .pipeline folder keep information needed only for CI/CD automation. Not related to project functionality or structure. Such files need to be ignored and not stored in repository. 

## Approach

Adding folder to .gitignore 

## Pull Request status

* [x] implementation
