### PR TITLE
Improve support for multiple broker installations in same cluster

### DIFF
--- a/charts/service-broker-proxy-k8s/README.md
+++ b/charts/service-broker-proxy-k8s/README.md
@@ -31,7 +31,7 @@ helm repo add peripli 'https://peripli.github.io'
 
 ```bash
 kubectl create namespace service-broker-proxy
-helm install service-broker-proxy peripli/service-broker-proxy-k8s \
+helm install sb-proxy peripli/service-broker-proxy-k8s \
   --namespace service-broker-proxy \
   --version <VERSION> \
   --set config.sm.url=<SM_URL> \
@@ -41,6 +41,9 @@ helm install service-broker-proxy peripli/service-broker-proxy-k8s \
 
 **Note:** Make sure you substitute &lt;SM_URL&gt; with the Service Manager url, &lt;USER&gt; and &lt;PASSWORD&gt; with the credentials returned from cluster registration in Service Manager (see above).
 Substitute \<VERSION> with the specific version you require. If this is not set, the latest version is used.
+
+The default configuration will register service brokers as cluster resources, making the services available in all cluster namespaces. To target a specific namespace, you can set the `targetNamespace`
+value to the helm install command, for example: `--set targetNamespace=my-namespace`.
 
 To use your own images you can set `image.repository`, `image.tag` and `image.pullPolicy` to the helm install command. In case your image is pulled from a private repository, you can use
 `image.pullsecret` to name a secret containing the credentials.
@@ -57,4 +60,5 @@ Parameter | Description | Default
 `config.sm.url` | service manager url | `http://service-manager.dev.cfdev.sh`
 `sm.user` | username for service manager | `admin`
 `sm.password` | password for service manager | `admin`
+`targetNamespace` | namespace in which services will be available, if not specified services will be available in all namespaces | 
 `securityContext` | Custom [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for server containers | `{}`

--- a/charts/service-broker-proxy-k8s/templates/_helpers.tpl
+++ b/charts/service-broker-proxy-k8s/templates/_helpers.tpl
@@ -17,9 +17,17 @@ If release name contains chart name it will be used as a full name.
 {{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- if contains $name .Release.Name -}}
+{{- if .Values.targetNamespace -}}
+{{- printf "%s-%s" .Release.Name .Values.targetNamespace | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- else -}}
+{{- if .Values.targetNamespace -}}
+{{- printf "%s-%s-%s" .Release.Name $name .Values.targetNamespace | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/service-broker-proxy-k8s/templates/rbac.yaml
+++ b/charts/service-broker-proxy-k8s/templates/rbac.yaml
@@ -1,3 +1,127 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ template "service-broker-proxy.fullname" . }}-regsecretviewer
+  labels:
+    app: {{ template "service-broker-proxy.name" . }}
+    chart: {{ template "service-broker-proxy.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "create", "delete", "update", "patch"]
+
+---
+
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "service-broker-proxy.fullname" . }}-regsecretviewer
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "service-broker-proxy.name" . }}
+    chart: {{ template "service-broker-proxy.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  kind: Role
+  name: {{ template "service-broker-proxy.fullname" . }}-regsecretviewer
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ template "service-broker-proxy.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+
+{{- if .Values.targetNamespace }}
+
+---
+
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  namespace: {{ .Values.targetNamespace }}
+  name: {{ template "service-broker-proxy.fullname" . }}
+  labels:
+    app: {{ template "service-broker-proxy.name" . }}
+    chart: {{ template "service-broker-proxy.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+  - apiGroups: ["servicecatalog.k8s.io"]
+    resources:
+    - servicebrokers
+    verbs:
+      - "*"
+
+---
+
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: {{ .Values.targetNamespace }}
+  name: {{ template "service-broker-proxy.fullname" . }}
+  labels:
+    app: {{ template "service-broker-proxy.name" . }}
+    chart: {{ template "service-broker-proxy.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  kind: Role
+  name: {{ template "service-broker-proxy.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ template "service-broker-proxy.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+
+{{- if ne .Values.targetNamespace .Release.Namespace }}
+
+---
+
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  namespace: {{ .Values.targetNamespace }}
+  name: {{ template "service-broker-proxy.fullname" . }}-brokersecretviewer
+  labels:
+    app: {{ template "service-broker-proxy.name" . }}
+    chart: {{ template "service-broker-proxy.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "create", "delete", "update", "patch"]
+
+---
+
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "service-broker-proxy.fullname" . }}-brokersecretviewer
+  namespace: {{ .Values.targetNamespace }}
+  labels:
+    app: {{ template "service-broker-proxy.name" . }}
+    chart: {{ template "service-broker-proxy.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  kind: Role
+  name: {{ template "service-broker-proxy.fullname" . }}-brokersecretviewer
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "service-broker-proxy.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+
+{{- end}}
+
+{{- else}}
+
+---
+
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
@@ -10,11 +134,7 @@ metadata:
 rules:
 - apiGroups: ["servicecatalog.k8s.io"]
   resources:
-  {{- if .Values.targetNamespace }}
-  - servicebrokers
-  {{- else}}
   - clusterservicebrokers
-  {{- end}}
   verbs:
   - "*"
 
@@ -38,84 +158,4 @@ subjects:
   name: {{ template "service-broker-proxy.fullname" . }}
   namespace: {{ .Release.Namespace }}
 
----
-
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
-metadata:
-  namespace: {{ .Release.Namespace }}
-  name: {{ template "service-broker-proxy.fullname" . }}-regsecretviewer
-  labels:
-    app: {{ template "service-broker-proxy.name" . }}
-    chart: {{ template "service-broker-proxy.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-rules:
-- apiGroups: [""]
-  resources: ["secrets"]
-  verbs: ["get", "create", "delete", "update", "patch"]
-
----
-
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: {{ template "service-broker-proxy.fullname" . }}
-  namespace: {{ .Release.Namespace }}
-  labels:
-    app: {{ template "service-broker-proxy.name" . }}
-    chart: {{ template "service-broker-proxy.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-roleRef:
-  kind: Role
-  name: {{ template "service-broker-proxy.fullname" . }}-regsecretviewer
-  apiGroup: rbac.authorization.k8s.io
-subjects:
-- kind: ServiceAccount
-  name: {{ template "service-broker-proxy.fullname" . }}
-  namespace: {{ .Release.Namespace }}
-
-{{- if .Values.targetNamespace }}
-{{- if ne .Values.targetNamespace .Release.Namespace }}
-
----
-
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
-metadata:
-  namespace: {{ .Values.targetNamespace }}
-  name: {{ template "service-broker-proxy.fullname" . }}-regsecretviewer
-  labels:
-    app: {{ template "service-broker-proxy.name" . }}
-    chart: {{ template "service-broker-proxy.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-rules:
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["get", "create", "delete", "update", "patch"]
-
----
-
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: {{ template "service-broker-proxy.fullname" . }}
-  namespace: {{ .Values.targetNamespace }}
-  labels:
-    app: {{ template "service-broker-proxy.name" . }}
-    chart: {{ template "service-broker-proxy.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-roleRef:
-  kind: Role
-  name: {{ template "service-broker-proxy.fullname" . }}-regsecretviewer
-  apiGroup: rbac.authorization.k8s.io
-subjects:
-  - kind: ServiceAccount
-    name: {{ template "service-broker-proxy.fullname" . }}
-    namespace: {{ .Release.Namespace }}
-
-{{- end}}
 {{- end}}


### PR DESCRIPTION
- Full name in helm chart updated to include the target namespace (if specified) to avoid resource name conflicts when installing multiple agents in the same cluster. 
- Added documentation for target namespace
- Replaced cluster role with role in case target namespace is defined to reduce the assigned permissions to the minimum required