### PR TITLE
verify broker name is in lower case letters

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -24,7 +24,15 @@
   version = "v1.0.1"
 
 [[projects]]
-  digest = "1:a9038396ad1196fb78a26a43f073f6c66005bf7923aae371b72956c660a8786b"
+  digest = "1:de1c2f0af309f0a401c5d4acfd001882a3051de9d921222dd8d39fe38ffd750e"
+  name = "github.com/Kount/pq-timeouts"
+  packages = ["."]
+  pruneopts = ""
+  revision = "079ba81f56daf25f2c22b7b2c224f5a9ba38840c"
+  version = "v1.0.0"
+
+[[projects]]
+  digest = "1:a189b2fd9b9dce53fc869819589b5e9af4b6c018fc6324d327d84ba80cad57b5"
   name = "github.com/Peripli/service-broker-proxy"
   packages = [
     "pkg/authn",
@@ -38,11 +46,11 @@
     "pkg/util",
   ]
   pruneopts = ""
-  revision = "aa8d0fa44134ab65f6a82223cb1cfe36b940f440"
-  version = "v0.10.0"
+  revision = "917c25ffb90419929af585ab80090f4b2456ba90"
+  version = "v0.11.9"
 
 [[projects]]
-  digest = "1:7b7bae3462654a33ac9f1fa3496637bb90344c10f80096e7a7e601018631ddfa"
+  digest = "1:4c83d809553ee9f90590883f11f8728fb6c2611eeb7f1bc9765b005f600f756d"
   name = "github.com/Peripli/service-manager"
   packages = [
     "api",
@@ -87,8 +95,8 @@
     "storage/service_plans",
   ]
   pruneopts = ""
-  revision = "e82055cd99aa853f58b2203d8cfcfdd4d629e4de"
-  version = "v0.14.0"
+  revision = "700d4b92ac9159ce165c6faea87a1fd5009f75c8"
+  version = "v0.16.10"
 
 [[projects]]
   digest = "1:fc70ddbcaf8a43101a79cb0a19f8fe6a2792a5280b90e083140de008139f0db0"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -969,6 +969,7 @@
     "k8s.io/api/core/v1",
     "k8s.io/apimachinery/pkg/api/errors",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
+    "k8s.io/apimachinery/pkg/types",
     "k8s.io/client-go/kubernetes",
     "k8s.io/client-go/rest",
     "k8s.io/client-go/tools/clientcmd",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -10,8 +10,7 @@
 
 [[constraint]]
   name = "github.com/Peripli/service-broker-proxy"
-  # TODO: chanhe to master before merge
-  branch = "add-platform-name-provider"
+  version = "=0.11.9"
 
 [[constraint]]
   name = "github.com/onsi/ginkgo"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -10,7 +10,8 @@
 
 [[constraint]]
   name = "github.com/Peripli/service-broker-proxy"
-  version = "=0.10.0"
+  # TODO: chanhe to master before merge
+  branch = "add-platform-name-provider"
 
 [[constraint]]
   name = "github.com/onsi/ginkgo"

--- a/pkg/k8s/client/client.go
+++ b/pkg/k8s/client/client.go
@@ -8,6 +8,7 @@ import (
 	servicecatalog "github.com/kubernetes-sigs/service-catalog/pkg/svcat/service-catalog"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"strings"
 	"sync"
 
 	"github.com/Peripli/service-broker-proxy/pkg/platform"
@@ -222,6 +223,7 @@ func (pc *PlatformClient) GetBrokers(ctx context.Context) ([]*platform.ServiceBr
 
 // GetBrokerByName returns the service-broker with the specified name currently registered in kubernetes service-catalog with.
 func (pc *PlatformClient) GetBrokerByName(ctx context.Context, name string) (*platform.ServiceBroker, error) {
+	name = strings.ToLower(name)
 	var broker servicecatalog.Broker
 	var brokerUID types.UID
 
@@ -250,6 +252,7 @@ func (pc *PlatformClient) GetBrokerByName(ctx context.Context, name string) (*pl
 
 // CreateBroker registers a new broker in kubernetes service-catalog.
 func (pc *PlatformClient) CreateBroker(ctx context.Context, r *platform.CreateServiceBrokerRequest) (*platform.ServiceBroker, error) {
+	r.Name = strings.ToLower(r.Name)
 	if err := pc.updateBrokerPlatformSecret(r.ID, r.Username, r.Password); err != nil {
 		return nil, err
 	}
@@ -291,6 +294,7 @@ func (pc *PlatformClient) CreateBroker(ctx context.Context, r *platform.CreateSe
 
 // DeleteBroker deletes an existing broker in from kubernetes service-catalog.
 func (pc *PlatformClient) DeleteBroker(ctx context.Context, r *platform.DeleteServiceBrokerRequest) error {
+	r.Name = strings.ToLower(r.Name)
 	if pc.isClusterScoped() {
 		if err := pc.platformAPI.DeleteSecret(pc.secretNamespace, r.ID); err != nil {
 			return fmt.Errorf("error deleting broker credentials secret: %v", err)
@@ -307,6 +311,7 @@ func (pc *PlatformClient) DeleteBroker(ctx context.Context, r *platform.DeleteSe
 
 // UpdateBroker updates a service broker in the kubernetes service-catalog.
 func (pc *PlatformClient) UpdateBroker(ctx context.Context, r *platform.UpdateServiceBrokerRequest) (*platform.ServiceBroker, error) {
+	r.Name = strings.ToLower(r.Name)
 	if r.Username != "" && r.Password != "" {
 		if err := pc.updateBrokerPlatformSecret(r.ID, r.Username, r.Password); err != nil {
 			return nil, err
@@ -353,6 +358,7 @@ func (pc *PlatformClient) UpdateBroker(ctx context.Context, r *platform.UpdateSe
 // Fetch the new catalog information from reach service-broker registered in kubernetes,
 // so that it is visible in the kubernetes service-catalog.
 func (pc *PlatformClient) Fetch(ctx context.Context, r *platform.UpdateServiceBrokerRequest) error {
+	r.Name = strings.ToLower(r.Name)
 	if r.Username != "" && r.Password != "" {
 		if err := pc.updateBrokerPlatformSecret(r.ID, r.Username, r.Password); err != nil {
 			return err

--- a/pkg/k8s/client/client.go
+++ b/pkg/k8s/client/client.go
@@ -225,19 +225,18 @@ func (pc *PlatformClient) GetBrokers(ctx context.Context) ([]*platform.ServiceBr
 
 // GetBrokerByName returns the service-broker with the specified name currently registered in kubernetes service-catalog with.
 func (pc *PlatformClient) GetBrokerByName(ctx context.Context, name string) (*platform.ServiceBroker, error) {
-	lowerCaseBrokerName := strings.ToLower(name)
 	var broker servicecatalog.Broker
 	var brokerUID types.UID
 
 	if pc.isClusterScoped() {
-		clusterBroker, err := pc.platformAPI.RetrieveClusterServiceBrokerByName(lowerCaseBrokerName)
+		clusterBroker, err := pc.platformAPI.RetrieveClusterServiceBrokerByName(name)
 		if err != nil {
 			return nil, fmt.Errorf("unable to get cluster-scoped broker (%s)", err)
 		}
 
 		broker, brokerUID = clusterBroker, clusterBroker.GetUID()
 	} else {
-		namespaceBroker, err := pc.platformAPI.RetrieveNamespaceServiceBrokerByName(lowerCaseBrokerName, pc.targetNamespace)
+		namespaceBroker, err := pc.platformAPI.RetrieveNamespaceServiceBrokerByName(name, pc.targetNamespace)
 		if err != nil {
 			return nil, fmt.Errorf("unable to get namespace-scoped broker (%s)", err)
 		}
@@ -254,14 +253,13 @@ func (pc *PlatformClient) GetBrokerByName(ctx context.Context, name string) (*pl
 
 // CreateBroker registers a new broker in kubernetes service-catalog.
 func (pc *PlatformClient) CreateBroker(ctx context.Context, r *platform.CreateServiceBrokerRequest) (*platform.ServiceBroker, error) {
-	lowerCaseBrokerName := strings.ToLower(r.Name)
 	if err := pc.updateBrokerPlatformSecret(r.ID, r.Username, r.Password); err != nil {
 		return nil, err
 	}
 	var brokerUID types.UID
 
 	if pc.isClusterScoped() {
-		broker := newClusterServiceBroker(lowerCaseBrokerName, r.BrokerURL, &v1beta1.ObjectReference{
+		broker := newClusterServiceBroker(r.Name, r.BrokerURL, &v1beta1.ObjectReference{
 			Name:      r.ID,
 			Namespace: pc.secretNamespace,
 		})
@@ -274,7 +272,7 @@ func (pc *PlatformClient) CreateBroker(ctx context.Context, r *platform.CreateSe
 		}
 		brokerUID = csb.GetUID()
 	} else {
-		broker := newNamespaceServiceBroker(lowerCaseBrokerName, r.BrokerURL, &v1beta1.LocalObjectReference{
+		broker := newNamespaceServiceBroker(r.Name, r.BrokerURL, &v1beta1.LocalObjectReference{
 			Name: r.ID,
 		})
 		broker.Spec.CommonServiceBrokerSpec.RelistBehavior = "Manual"
@@ -288,7 +286,7 @@ func (pc *PlatformClient) CreateBroker(ctx context.Context, r *platform.CreateSe
 
 	return &platform.ServiceBroker{
 		GUID:      string(brokerUID),
-		Name:      lowerCaseBrokerName,
+		Name:      r.Name,
 		BrokerURL: r.BrokerURL,
 	}, nil
 
@@ -296,24 +294,22 @@ func (pc *PlatformClient) CreateBroker(ctx context.Context, r *platform.CreateSe
 
 // DeleteBroker deletes an existing broker in from kubernetes service-catalog.
 func (pc *PlatformClient) DeleteBroker(ctx context.Context, r *platform.DeleteServiceBrokerRequest) error {
-	lowerCaseBrokerName := strings.ToLower(r.Name)
 	if pc.isClusterScoped() {
 		if err := pc.platformAPI.DeleteSecret(pc.secretNamespace, r.ID); err != nil {
 			return fmt.Errorf("error deleting broker credentials secret: %v", err)
 		}
-		return pc.platformAPI.DeleteClusterServiceBroker(lowerCaseBrokerName, &v1.DeleteOptions{})
+		return pc.platformAPI.DeleteClusterServiceBroker(r.Name, &v1.DeleteOptions{})
 	}
 
 	if err := pc.platformAPI.DeleteSecret(pc.targetNamespace, r.ID); err != nil {
 		return fmt.Errorf("error deleting broker credentials secret in namespace %s: %v", pc.targetNamespace, err)
 	}
-	return pc.platformAPI.DeleteNamespaceServiceBroker(lowerCaseBrokerName, pc.targetNamespace, &v1.DeleteOptions{})
+	return pc.platformAPI.DeleteNamespaceServiceBroker(r.Name, pc.targetNamespace, &v1.DeleteOptions{})
 
 }
 
 // UpdateBroker updates a service broker in the kubernetes service-catalog.
 func (pc *PlatformClient) UpdateBroker(ctx context.Context, r *platform.UpdateServiceBrokerRequest) (*platform.ServiceBroker, error) {
-	lowerCaseBrokerName := strings.ToLower(r.Name)
 	if r.Username != "" && r.Password != "" {
 		if err := pc.updateBrokerPlatformSecret(r.ID, r.Username, r.Password); err != nil {
 			return nil, err
@@ -325,7 +321,7 @@ func (pc *PlatformClient) UpdateBroker(ctx context.Context, r *platform.UpdateSe
 
 	if pc.isClusterScoped() {
 		// Only broker url and secret-references are updateable
-		broker := newClusterServiceBroker(lowerCaseBrokerName, r.BrokerURL, &v1beta1.ObjectReference{
+		broker := newClusterServiceBroker(r.Name, r.BrokerURL, &v1beta1.ObjectReference{
 			Name:      r.ID,
 			Namespace: pc.secretNamespace,
 		})
@@ -338,7 +334,7 @@ func (pc *PlatformClient) UpdateBroker(ctx context.Context, r *platform.UpdateSe
 		updatedBroker, updatedBrokerUID = updatedClusterBroker, updatedClusterBroker.GetUID()
 	} else {
 		// Only broker url and secret-references are updateable
-		broker := newNamespaceServiceBroker(lowerCaseBrokerName, r.BrokerURL, &v1beta1.LocalObjectReference{
+		broker := newNamespaceServiceBroker(r.Name, r.BrokerURL, &v1beta1.LocalObjectReference{
 			Name: r.ID,
 		})
 
@@ -360,7 +356,6 @@ func (pc *PlatformClient) UpdateBroker(ctx context.Context, r *platform.UpdateSe
 // Fetch the new catalog information from reach service-broker registered in kubernetes,
 // so that it is visible in the kubernetes service-catalog.
 func (pc *PlatformClient) Fetch(ctx context.Context, r *platform.UpdateServiceBrokerRequest) error {
-	lowerCaseBrokerName := strings.ToLower(r.Name)
 	if r.Username != "" && r.Password != "" {
 		if err := pc.updateBrokerPlatformSecret(r.ID, r.Username, r.Password); err != nil {
 			return err
@@ -368,10 +363,16 @@ func (pc *PlatformClient) Fetch(ctx context.Context, r *platform.UpdateServiceBr
 	}
 
 	if pc.isClusterScoped() {
-		return pc.platformAPI.SyncClusterServiceBroker(lowerCaseBrokerName, resyncBrokerRetryCount)
+		return pc.platformAPI.SyncClusterServiceBroker(r.Name, resyncBrokerRetryCount)
 	}
 
-	return pc.platformAPI.SyncNamespaceServiceBroker(lowerCaseBrokerName, pc.targetNamespace, resyncBrokerRetryCount)
+	return pc.platformAPI.SyncNamespaceServiceBroker(r.Name, pc.targetNamespace, resyncBrokerRetryCount)
+}
+
+// GetBrokerPlatformName enforces broker names to be as k8s requires.
+// Name will be later prefixed an suffixed by allowed strings, so we only make sure lowercase and replace underscore with hyphen.
+func (pc *PlatformClient) GetBrokerPlatformName(name string) string {
+	return strings.ReplaceAll(strings.ToLower(name), "_", "-")
 }
 
 func (pc *PlatformClient) updateBrokerPlatformSecret(name, username, password string) error {


### PR DESCRIPTION
Justification: k8s cannot register brokers with names containing capital letters