### PR TITLE
Bump alpine base image to 3.13.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -o /mai
 ########################################################
 # Build the runtime container
 ########################################################
-FROM alpine:3.13.2
+FROM alpine:3.13.5
 
 # required to use x.509 certs (HTTPS)
 RUN apk add --no-cache ca-certificates


### PR DESCRIPTION
**Description**

`alpine:3.13.2` has vulnerability issues:
- openssl 1.1.1j-r0 
  - CVE-2021-3450
  - CVE-2021-3449
- busybox 1.32.1-r3 
  - CVE-2021-28831
- apk-tools 2.12.1-r0 
  - CVE-2021-30139




--





