### PR TITLE
Bump alpine image version to 3.13.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -o /mai
 ########################################################
 # Build the runtime container
 ########################################################
-FROM alpine:3.13.5
+FROM alpine:3.13.6
 
 # required to use x.509 certs (HTTPS)
 RUN apk add --no-cache ca-certificates


### PR DESCRIPTION
Alpine 3.13.6 fixes:
- apk-tools:
  CVE-2021-36159
- openssl:
  CVE-2021-3711
  CVE-2021-3712

More info: https://alpinelinux.org/posts/Alpine-3.11.12-3.12.8.-3.13.6-released.html