### PR TITLE
Bump version for CVE-2021-44716 vulnerability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # docker container. The alpine build image has to match
 # the alpine image in the referencing runtime container.
 #########################################################
-FROM golang:1.13.4-alpine3.10 AS builder
+FROM golang:1.17.6-alpine3.10 AS builder
 
 # We need so that dep can fetch it's dependencies
 RUN apk --no-cache add git


### PR DESCRIPTION
Updated Golang version for CVE-2021-44716 vulnerability reported by Protecode. 
More details on vulnerability here - https://nvd.nist.gov/vuln/detail/CVE-2021-44716
