### PR TITLE
Make use of rbac.authorization.k8s.io/v1

### DIFF
--- a/charts/service-broker-proxy-k8s/templates/rbac.yaml
+++ b/charts/service-broker-proxy-k8s/templates/rbac.yaml
@@ -1,5 +1,5 @@
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ template "service-broker-proxy.fullname" . }}-regsecretviewer
@@ -39,7 +39,7 @@ subjects:
 ---
 
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: {{ .Values.targetNamespace }}
   name: {{ template "service-broker-proxy.fullname" . }}
@@ -81,7 +81,7 @@ subjects:
 ---
 
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: {{ .Values.targetNamespace }}
   name: {{ template "service-broker-proxy.fullname" . }}-brokersecretviewer
@@ -123,7 +123,7 @@ subjects:
 ---
 
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "service-broker-proxy.fullname" . }}
   labels:


### PR DESCRIPTION
Migrate RBAC resources to `rbac.authorization.k8s.io/v1`, because `rbac.authorization.k8s.io/v1beta1` is removed since k8s version => 1.22.

Fixes: #138